### PR TITLE
Enable use of StreamingParser from packages outside of HTTPSketch

### DIFF
--- a/Sources/HTTPSketch/BlueSocketDriver/BlueSocketConnectionListener.swift
+++ b/Sources/HTTPSketch/BlueSocketDriver/BlueSocketConnectionListener.swift
@@ -121,7 +121,7 @@ public class BlueSocketConnectionListener: ParserConnecting {
     
     
     /// Called by the parser to let us know that it's done with this socket
-    func closeWriter() {
+    public func closeWriter() {
         self.socketWriterQueue?.async { [weak self] in
             if (self?.readerSource?.isCancelled ?? true) {
                 self?.close()
@@ -213,7 +213,7 @@ public class BlueSocketConnectionListener: ParserConnecting {
     /// Called by the parser to give us data to send back out of the socket
     ///
     /// - Parameter bytes: Data object to be queued to be written to the socket
-    func queueSocketWrite(_ bytes: Data) {
+    public func queueSocketWrite(_ bytes: Data) {
         self.socketWriterQueue?.async { [ weak self ] in
             self?.write(bytes)
         }

--- a/Sources/HTTPSketch/HTTPResponse.swift
+++ b/Sources/HTTPSketch/HTTPResponse.swift
@@ -253,5 +253,131 @@ extension HTTPResponseStatus {
             return 511
         }
     }
+    
+    public static func from(code: UInt) -> HTTPResponseStatus? {
+        switch code {
+        case 100:
+            return .`continue`
+        case 101:
+            return .switchingProtocols
+        case 102:
+            return .processing
+        case 200:
+            return .ok
+        case 201:
+            return .created
+        case 202:
+            return .accepted
+        case 203:
+            return .nonAuthoritativeInformation
+        case 204:
+            return .noContent
+        case 205:
+            return .resetContent
+        case 206:
+            return .partialContent
+        case 207:
+            return .multiStatus
+        case 208:
+            return .alreadyReported
+        case 226:
+            return .imUsed
+        case 300:
+            return .multipleChoices
+        case 301:
+            return .movedPermanently
+        case 302:
+            return .found
+        case 303:
+            return .seeOther
+        case 304:
+            return .notModified
+        case 305:
+            return .useProxy
+        case 307:
+            return .temporaryRedirect
+        case 308:
+            return .permanentRedirect
+        case 400:
+            return .badRequest
+        case 401:
+            return .unauthorized
+        case 402:
+            return .paymentRequired
+        case 403:
+            return .forbidden
+        case 404:
+            return .notFound
+        case 405:
+            return .methodNotAllowed
+        case 406:
+            return .notAcceptable
+        case 407:
+            return .proxyAuthenticationRequired
+        case 408:
+            return .requestTimeout
+        case 409:
+            return .conflict
+        case 410:
+            return .gone
+        case 411:
+            return .lengthRequired
+        case 412:
+            return .preconditionFailed
+        case 413:
+            return .payloadTooLarge
+        case 414:
+            return .uriTooLong
+        case 415:
+            return .unsupportedMediaType
+        case 416:
+            return .rangeNotSatisfiable
+        case 417:
+            return .expectationFailed
+        case 421:
+            return .misdirectedRequest
+        case 422:
+            return .unprocessableEntity
+        case 423:
+            return .locked
+        case 424:
+            return .failedDependency
+        case 426:
+            return .upgradeRequired
+        case 428:
+            return .preconditionRequired
+        case 429:
+            return .tooManyRequests
+        case 431:
+            return .requestHeaderFieldsTooLarge
+        case 451:
+            return .unavailableForLegalReasons
+        case 500:
+            return .internalServerError
+        case 501:
+            return .notImplemented
+        case 502:
+            return .badGateway
+        case 503:
+            return .serviceUnavailable
+        case 504:
+            return .gatewayTimeout
+        case 505:
+            return .httpVersionNotSupported
+        case 506:
+            return .variantAlsoNegotiates
+        case 507:
+            return .insufficientStorage
+        case 508:
+            return .loopDetected
+        case 510:
+            return .notExtended
+        case 511:
+            return .networkAuthenticationRequired
+            
+        default:
+            return nil
+        }
+    }
 }
 


### PR DESCRIPTION
Enable use of StreamingParser from packages outside of HTTPSketch and add API to determine if a request was an upgrade request or not.

In addition a function was added to create a HTTPResponseStatus from a number.